### PR TITLE
Downgrading Steam's Fallout 3

### DIFF
--- a/Lite/lite-ttw.html
+++ b/Lite/lite-ttw.html
@@ -61,6 +61,7 @@ SOFTWARE.
     <div class="sidenavright">
         <a href="./lite-ttw.html">TTW</a>
             <ul>
+                <a href="./lite-ttw.html#downgrading_fallout3"><span style="font-size:.8vw;">Steam</span></a>
                 <a href="./lite-ttw.html#installing_ttw"><span style="font-size:.8vw;">Install</span></a>
                 <a href="./lite-ttw.html#activating_ttw"><span style="font-size:.8vw;">Activate</span></a>
             </ul>
@@ -72,6 +73,16 @@ SOFTWARE.
                     In this step, we will install and activate Tale of Two Wastelands through Mod Organizer 2.
                 </p>
         </h2>
+            <a class="internallink" href="#downgrading_fallout3"><h2 class="subheader" id="installing_ttw">Downgrading Fallout 3</h2></a>
+                  <blockquote class="blockquote">
+                      This step is only necessary if you have Fallout 3 installed from <b>Steam</b>.
+                  </blockquote>
+                  <ol class="standard_ol">
+                      <li>Make sure both Mod Organizer 2 and Fallout 3 are closed</li>
+                      <li>Download the <a href="https://cdn.discordapp.com/attachments/229685991475118093/898181596925001748/Fallout3Downgrader.7z" target="_blank">Fallout 3 Downgrader</a> file</li>
+                      <li>Extract the contents of the <strong>Fallout3Downgrader</strong> archive to the <abbr title="Steam\steamapps\common\Fallout 3 goty">Root</abbr> of Fallout 3</li>
+                      <li>Run <strong>Fallout3Downgrader.exe</strong></li>
+                  </ol>
             <a class="internallink" href="#installing_ttw"><h2 class="subheader" id="installing_ttw">Installing TTW</h2></a>
                 <blockquote class="blockquote">
                     If you run into any errors when installing, check the <a href="https://taleoftwowastelands.com/faq" target="_blank">FAQ</a> to see if it has the solution.

--- a/ttw.html
+++ b/ttw.html
@@ -64,6 +64,7 @@ SOFTWARE.
     <div class="sidenavright">
         <a href="./ttw.html">TTW</a>
             <ul>
+                <a href="./ttw.html#downgrading_fallout3"><span style="font-size:.8vw;">Steam</span></a>
                 <a href="./ttw.html#installing_ttw"><span style="font-size:.8vw;">Install</span></a>
                 <a href="./ttw.html#activating_ttw"><span style="font-size:.8vw;">Activate</span></a>
             </ul>
@@ -75,6 +76,16 @@ SOFTWARE.
                     In this step, we will install and activate Tale of Two Wastelands through Mod Organizer 2.
                 </p>
         </h2>
+            <a class="internallink" href="#downgrading_fallout3"><h2 class="subheader" id="installing_ttw">Downgrading Fallout 3</h2></a>
+                <blockquote class="blockquote">
+                    This step is only necessary if you have Fallout 3 installed from <b>Steam</b>.
+                </blockquote>
+                <ol class="standard_ol">
+                    <li>Make sure both Mod Organizer 2 and Fallout 3 are closed</li>
+                    <li>Download the <a href="https://cdn.discordapp.com/attachments/229685991475118093/898181596925001748/Fallout3Downgrader.7z" target="_blank">Fallout 3 Downgrader</a> file</li>
+                    <li>Extract the contents of the <strong>Fallout3Downgrader</strong> archive to the <abbr title="Steam\steamapps\common\Fallout 3 goty">Root</abbr> of Fallout 3</li>
+                    <li>Run <strong>Fallout3Downgrader.exe</strong></li>
+                </ol>
             <a class="internallink" href="#installing_ttw"><h2 class="subheader" id="installing_ttw">Installing TTW</h2></a>
                 <blockquote class="blockquote">
                     If you run into any errors when installing, check the <a href="https://taleoftwowastelands.com/faq" target="_blank">FAQ</a> to see if it has the solution.


### PR DESCRIPTION
Since Bethesda / Microsoft recently recompiled Fallout 3 and pushed the update to Steam, users can't use the 3.2 TTW installer atm to install TTW. This commit adds a temporary step to downgrade Fallout 3 so the TTW installer works for Steam users.
